### PR TITLE
byte2sring is working too hard

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,0 +1,8 @@
+LIB=	pam_multipassword
+SRCS=	pam_duress.c
+
+CFLAGS+=-DHASH_ROUNDS=1000
+
+WARNS=	7
+
+.include <bsd.lib.mk>

--- a/pam_duress.c
+++ b/pam_duress.c
@@ -31,9 +31,9 @@ static void
 byte2string(const byte *in, char *out)
 {
     int i;
-    out[0] = '\0';
-    for(i=0; i<SHA256_DIGEST_LENGTH; ++i)
-        sprintf(out, "%s%02x", out, in[i]);
+
+    for(i = 0; i < SHA256_DIGEST_LENGTH; i += 1, out += 2)
+        sprintf(out, "%02x", in[i]);
 }
 
 static void


### PR DESCRIPTION
The byte2string function is working too hard rewriting parts of its output _with itself_ 32 times :-)

The addition of `BSDmakefile` need not be merged (may be too early for that anyway), but, having pushed it into my own branch already, I do not know, how to exclude it from subsequent pull-requests...