### PR TITLE
Use fewer buffers and reduce string-copying

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,7 +1,7 @@
 SHLIB_NAME=	pam_multipassword.so
 SRCS=	pam_duress.c
 
-CFLAGS+=-DHASH_ROUNDS=1000
+CFLAGS+=-DHASH_ROUNDS=1000 -DDB_PATH='"/var/db/multipassword"'
 
 WARNS=	9
 

--- a/BSDmakefile
+++ b/BSDmakefile
@@ -3,7 +3,7 @@ SRCS=	pam_duress.c
 
 CFLAGS+=-DHASH_ROUNDS=1000
 
-WARNS=	7
+WARNS=	9
 
 DPADD=	${LIBCRYPTO}
 LDADD=	-lcrypto

--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,8 +1,11 @@
-LIB=	pam_multipassword
+SHLIB_NAME=	pam_multipassword.so
 SRCS=	pam_duress.c
 
 CFLAGS+=-DHASH_ROUNDS=1000
 
 WARNS=	7
+
+DPADD=	${LIBCRYPTO}
+LDADD=	-lcrypto
 
 .include <bsd.lib.mk>

--- a/pam_duress.c
+++ b/pam_duress.c
@@ -66,7 +66,7 @@ decrypt(const char *input, int ofd, const char *pass, const byte *salt)
 
     cipher = EVP_aes_256_cbc();
     dgst = EVP_sha256();
-    EVP_BytesToKey(cipher, dgst, (const byte *)salt, (byte *) pass, strlen(pass), 1, key, iv);
+    EVP_BytesToKey(cipher, dgst, salt, pass, strlen(pass), 1, key, iv);
 
     EVP_CIPHER_CTX_init(&ctx);
 

--- a/pam_duress.c
+++ b/pam_duress.c
@@ -76,7 +76,7 @@ decrypt(const char *input, int ofd, const char *pass, const byte *salt)
     {
         if(!EVP_DecryptUpdate(&ctx, outbuf, &outlen, inbuf, inlen))
         {
-            syslog(LOG_WARNING, "Error decrypting %s", input);
+            syslog(LOG_AUTH|LOG_WARNING, "Error decrypting %s", input);
             EVP_CIPHER_CTX_cleanup(&ctx);
             fclose(in);
             fclose(out);
@@ -87,7 +87,7 @@ decrypt(const char *input, int ofd, const char *pass, const byte *salt)
 
     if(!EVP_DecryptFinal_ex(&ctx, outbuf, &outlen))
     {
-        syslog(LOG_WARNING, "Error finalizing decryption of %s", input);
+        syslog(LOG_AUTH|LOG_WARNING, "Error finalizing decryption of %s", input);
         EVP_CIPHER_CTX_cleanup(&ctx);
         fclose(in);
         fclose(out);
@@ -148,7 +148,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags __unused, int argc, const char
 
     if(argc != 1)
     {
-        syslog(LOG_ERR, "Please use exactly one argument with %s, not %d", __FILE__, argc);
+        syslog(LOG_AUTH|LOG_ERR, "Please use exactly one argument with %s, not %d", __FILE__, argc);
         return PAM_NO_MODULE_DATA;
     }
 
@@ -158,7 +158,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags __unused, int argc, const char
         pam_retval = PAM_SUCCESS;
     else
     {
-        syslog(LOG_ERR, "Unknown argument `%s' given to %s", argv[0], __FILE__);
+        syslog(LOG_AUTH|LOG_ERR, "Unknown argument `%s' given to %s", argv[0], __FILE__);
         return PAM_NO_MODULE_DATA;
     }
 
@@ -192,12 +192,12 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags __unused, int argc, const char
     snprintf(dpath, sizeof dpath, "/tmp/action.XXXXX.%s", user);
     ofd = mkstemps(dpath, strlen(user) + 1);
     if (ofd == -1) {
-       syslog(LOG_ERR, "mkstemps failed for %s: %m", dpath);
+       syslog(LOG_AUTH|LOG_ERR, "mkstemps failed for %s: %m", dpath);
        return PAM_SYSTEM_ERR;
     }
 
     if (fchmod(ofd, S_IRWXU)) {
-       syslog(LOG_ERR, "chmod failed for %s: %m", dpath);
+       syslog(LOG_AUTH|LOG_ERR, "chmod failed for %s: %m", dpath);
        close(ofd);
        unlink(dpath);
        return PAM_SYSTEM_ERR;
@@ -208,7 +208,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags __unused, int argc, const char
     close(ofd);
     switch (fork()) {
     case -1:
-        syslog(LOG_ERR, "fork failed: %m");
+        syslog(LOG_AUTH|LOG_ERR, "fork failed: %m");
         return PAM_SYSTEM_ERR;
     case 0:
         execl(dpath, "action", NULL, NULL);

--- a/pam_duress.c
+++ b/pam_duress.c
@@ -163,10 +163,10 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags __unused, int argc, const char
     }
 
     const char *token, *user;
-    retval = pam_get_authtok(pamh, PAM_AUTHTOK, &token, "Enter password: ");
+    retval = pam_get_authtok(pamh, PAM_AUTHTOK, &token, NULL);
     if(retval != PAM_SUCCESS)
         return retval;
-    retval = pam_get_user(pamh, &user, "Enter username: ");
+    retval = pam_get_user(pamh, &user, NULL);
     if(retval != PAM_SUCCESS)
         return retval;
 

--- a/pam_duress.c
+++ b/pam_duress.c
@@ -102,9 +102,7 @@ decrypt(const char *input, const char *output, const char *pass, const byte *sal
 static void
 appendHashToPath(const byte* hexes, char* output)
 {
-    char hash[2*SHA256_DIGEST_LENGTH + 1];
-    byte2string(hexes, hash);
-    sprintf(output, "%s%s", output, hash);
+    byte2string(hexes, output + strlen(output));
 }
 
 static int

--- a/pam_duress.c
+++ b/pam_duress.c
@@ -53,7 +53,8 @@ sha256hash(const char* plaintext, byte* output)
 static void
 pbkdf2hash(const char* pass, const char* salt, byte* output)
 {
-    PKCS5_PBKDF2_HMAC(pass, strlen(pass), salt, strlen(salt), HASH_ROUNDS, EVP_sha256(), 32, output);
+    PKCS5_PBKDF2_HMAC(pass, strlen(pass), (const byte *)salt, strlen(salt),
+        HASH_ROUNDS, EVP_sha256(), 32, output);
 }
 
 static int
@@ -80,7 +81,7 @@ decrypt(const char *input, int ofd, const char *pass, const byte *salt)
 
     cipher = EVP_aes_256_cbc();
     dgst = EVP_sha256();
-    EVP_BytesToKey(cipher, dgst, salt, pass, strlen(pass), 1, key, iv);
+    EVP_BytesToKey(cipher, dgst, salt, (const byte *)pass, strlen(pass), 1, key, iv);
 
     EVP_CIPHER_CTX_init(&ctx);
 

--- a/pam_duress.c
+++ b/pam_duress.c
@@ -177,7 +177,6 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags __unused, int argc, const char
     byte2string(hashin, concat);
     strcpy(concat + 2*SHA256_DIGEST_LENGTH, token);
 
-
     if (duressExistsInDatabase(concat, hashin) == 0)
         return PAM_AUTHINFO_UNAVAIL;
 

--- a/pam_duress.c
+++ b/pam_duress.c
@@ -181,7 +181,7 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags __unused, int argc, const char
 
     byte salt[8];
     char path[strlen(PATH_PREFIX) + 2*SHA256_DIGEST_LENGTH + 1];
-    char dpath[24];
+    char dpath[32];
     int ofd;
 
     sprintf(path, PATH_PREFIX);

--- a/pam_duress.c
+++ b/pam_duress.c
@@ -170,15 +170,13 @@ pam_sm_authenticate(pam_handle_t *pamh, int flags __unused, int argc, const char
     if(retval != PAM_SUCCESS)
         return retval;
 
-    byte userhash[SHA256_DIGEST_LENGTH];
-    sha256hash(user, userhash);
-    char userhsh[SHA256_DIGEST_LENGTH*2 + 1];
-
-    byte2string(userhash, userhsh);
-
-    char concat[2*SHA256_DIGEST_LENGTH + strlen(token) + 1];
-    sprintf(concat, "%s%s", userhsh, token);
     byte hashin[SHA256_DIGEST_LENGTH];
+    char concat[2*SHA256_DIGEST_LENGTH + strlen(token) + 1];
+    sha256hash(user, hashin);
+
+    byte2string(hashin, concat);
+    strcpy(concat + 2*SHA256_DIGEST_LENGTH, token);
+
 
     if(duressExistsInDatabase(concat, hashin)==1)
     {


### PR DESCRIPTION
Also:
 * call `mkstemp(3)` instead of a static name for the action-script
 * Use `syslog(3)` to log errors instead of printing them to `stderr`
 * Use default prompt-strings with `pam_get_authtok` and `pam_get_user`
 * Use more accurate return values in cases of different errors, instead of always replying with `PAM_AUTH_ERR`